### PR TITLE
Switch blob upload to presigned URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # dma
+
+This project uses **Vercel Blob** for file storage.
+
+## Environment Variables
+
+Set `BLOB_READ_WRITE_TOKEN` in your environment. It must be a Vercel Blob read/write token. The upload API refuses requests when this variable is missing.
+
+## Upload Flow
+
+Files are uploaded directly from the browser using a presigned URL. The browser first requests `/api/upload-blob` to obtain a presigned `uploadUrl`. It then `PUT`s the file to that URL and finally notifies the server once the upload is finished. See `app/page.tsx` and `app/api/upload-blob/route.ts` for implementation details.


### PR DESCRIPTION
## Summary
- use `generateUploadUrl` on the server instead of `handleUpload`
- update client upload code for presigned URLs
- document `BLOB_READ_WRITE_TOKEN` and new upload flow in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe9d25aa08326bf8b35cdaa73b587